### PR TITLE
Changing ALE not to run when typing

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -139,3 +139,4 @@ nmap <S-Enter> O<Esc>
 
 " Fix files with prettier, and then ESLint.
 let b:ale_fixers = ['rubocop', 'reek', 'scss_lint']
+let g:ale_lint_on_text_changed = ‘never’


### PR DESCRIPTION
This PR changes ALE to *not* run when you're typing so that it does not decrease typing speed.

This may mess with your autocomplete, but it helped speed up my development by a lot!